### PR TITLE
New copy relative path command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,10 +34,7 @@ function CopyActiveFilePath() {
     if (config.fullpath) {
         vscode.commands.executeCommand('workbench.action.files.copyPathOfActiveFile');
     } else {
-        filePath = vscode.window.activeTextEditor.document.fileName;
-        relFilePath = path.relative(vscode.workspace.rootPath, filePath);
-        relFilePath = relFilePath.replace('\\', '\\\\') // Because Windows...
-        copy(relFilePath);
+        vscode.commands.executeCommand('extension.copyRelativePathOfActiveFile')
     }
 }
 
@@ -45,7 +42,7 @@ function CreateStatusBar() {
     var config = vscode.workspace.getConfiguration('ActiveFileInStatusBar');
     var sb = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     sb.text = '';
-    sb.command = 'extension.copyActiveFilePath';
+    sb.command = 'extension.copyRelativePathOfActiveFile';
     if (config.revealFile) {
         sb.command = 'workbench.action.files.revealActiveFileInWindows';
     }
@@ -55,8 +52,11 @@ function CreateStatusBar() {
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
-    var copyActiveFileCommand = vscode.commands.registerCommand('extension.copyActiveFilePath', function () {
-        CopyActiveFilePath();
+    var copyActiveFileCommand = vscode.commands.registerCommand('extension.copyRelativePathOfActiveFile', function () {
+        filePath = vscode.window.activeTextEditor.document.fileName;
+        relFilePath = path.relative(vscode.workspace.rootPath, filePath);
+        relFilePath = relFilePath.replace('\\', '\\\\') // Because Windows...
+        copy(relFilePath);
     });
     context.subscriptions.push(copyActiveFileCommand);
 

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 var vscode = require('vscode');
 var path = require('path');
+var copy = require('node-clipboard');
 
 var sb = null;
 
@@ -27,11 +28,24 @@ function OnStatusBarUpdate( textEditor ) {
     }
 }
 
+function CopyActiveFilePath() {
+    var config = vscode.workspace.getConfiguration('ActiveFileInStatusBar');
+
+    if (config.fullpath) {
+        vscode.commands.executeCommand('workbench.action.files.copyPathOfActiveFile');
+    } else {
+        filePath = vscode.window.activeTextEditor.document.fileName;
+        relFilePath = path.relative(vscode.workspace.rootPath, filePath);
+        relFilePath = relFilePath.replace('\\', '\\\\') // Because Windows...
+        copy(relFilePath);
+    }
+}
+
 function CreateStatusBar() {
     var config = vscode.workspace.getConfiguration('ActiveFileInStatusBar');
     var sb = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     sb.text = '';
-    sb.command = 'workbench.action.files.copyPathOfActiveFile';
+    sb.command = 'extension.copyActiveFilePath';
     if (config.revealFile) {
         sb.command = 'workbench.action.files.revealActiveFileInWindows';
     }
@@ -41,6 +55,10 @@ function CreateStatusBar() {
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
+    var copyActiveFileCommand = vscode.commands.registerCommand('extension.copyActiveFilePath', function () {
+        CopyActiveFilePath();
+    });
+    context.subscriptions.push(copyActiveFileCommand);
 
     var config = vscode.workspace.getConfiguration('ActiveFileInStatusBar');
     if (config.enable) {
@@ -50,7 +68,6 @@ function activate(context) {
 
         context.subscriptions.push(sb);
     }
-
 }
 exports.activate = activate;
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "icon_attribution": "Icon made by [Anton Saputro](http://www.flaticon.com/authors/anton-saputro) from [Flaticon](http://www.flaticon.com) is licensed by [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/)",
 	"main": "./extension",
 	"contributes": {
+		"commands": [
+			{
+				"command": "extension.copyActiveFilePath",
+				"title": "Copy active file path"
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "ActiveFileInStatusBar configuration",
@@ -32,7 +38,7 @@
 				},
 				"ActiveFileInStatusBar.fullpath": {
 					"type": "boolean",
-					"default": true, 
+					"default": true,
 					"description": "Show fullpath or relative path in status bar."
 				},
 				"ActiveFileInStatusBar.revealFile": {
@@ -49,5 +55,8 @@
     },
 	"devDependencies": {
 		"vscode": "0.10.x"
-	}
+	},
+	"dependencies": {
+        "node-clipboard": "1.2.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "extension.copyActiveFilePath",
-				"title": "Copy active file path"
+				"command": "extension.copyRelativePathOfActiveFile",
+				"title": "Files: Copy Relative Path of Active File"
 			}
 		],
 		"configuration": {
@@ -39,7 +39,7 @@
 				"ActiveFileInStatusBar.fullpath": {
 					"type": "boolean",
 					"default": true,
-					"description": "Show fullpath or relative path in status bar."
+					"description": "Show filepath in status bar."
 				},
 				"ActiveFileInStatusBar.revealFile": {
 					"type": "boolean",


### PR DESCRIPTION
A new relative path command for copying the relative path has been created. When relative setting is set to true, this new command is executed instead of the in-built API command.
