### PR TITLE
added keys and logic for the search immediately after clicking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![ActiveFileInStatusBar in action](media/ActiveFileInStatusBar.gif)
 
 ## Install ##
-Install [ActiveFileInStatusBar](https://marketplace.visualstudio.com/items?itemName=RoscoP.ActiveFileInStatusBar) directly from the Visual Studio Code extension gallery. 
+Install [ActiveFileInStatusBar](https://marketplace.visualstudio.com/items?itemName=RoscoP.ActiveFileInStatusBar) directly from the Visual Studio Code extension gallery.
 
 ## Options ##
 
@@ -17,6 +17,10 @@ Install [ActiveFileInStatusBar](https://marketplace.visualstudio.com/items?itemN
 "ActiveFileInStatusBar.revealFile": false,
 // Set text color for the filename in the status bar.
 "ActiveFileInStatusBar.color": "",
+// Do I need to search immediately after copying.
+"ActiveFileInStatusBar.searchАfterСopy": false,
+// Regex mask if you need to dissect the path before copying.
+"ActiveFileInStatusBar.regexPath": "string",
 ```
 
 ## Contribute ##

--- a/extension.js
+++ b/extension.js
@@ -59,7 +59,19 @@ function activate(context) {
             vscode.commands.executeCommand('workbench.action.files.revealActiveFileInWindows')
         }
         else {
-            copypaste.copy(sb.text)
+            copypaste.copy(
+                config.regexPath
+                    ? new RegExp(config.regexPath).exec(sb.text)
+                    : sb.text
+            )
+
+            if (config.searchАfterСopy) {
+                vscode.commands.executeCommand('workbench.view.search');
+
+                setTimeout(() => {
+                    vscode.commands.executeCommand('editor.action.clipboardPasteAction');
+                }, 100);
+            }
         }
     });
     context.subscriptions.push(disposable);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,16 @@
           "type": "string",
           "default": "",
           "description": "Set text color for the filename in the status bar."
+        },
+        "ActiveFileInStatusBar.searchАfterСopy": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do I need to search immediately after copying."
+        },
+        "ActiveFileInStatusBar.regexPath": {
+          "type": "string",
+          "default": "",
+          "description": "Regex mask if you need to dissect the path before copying."
         }
       }
     }


### PR DESCRIPTION

I think it will be convenient for many people, for me it is the most frequent case when I copy a file and want to find its calls, but due to the fact that the file is connected without extension or has additional nesting, you have to 1) open the search, 2) paste, 3) remove all unnecessary (.js) and so on