### PR TITLE
Fix copying on remote

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,4 @@
 var vscode = require('vscode');
-var copypaste = require('copy-paste');
 var path = require('path');
 
 var sb = null;
@@ -59,7 +58,7 @@ function activate(context) {
             vscode.commands.executeCommand('workbench.action.files.revealActiveFileInWindows')
         }
         else {
-            copypaste.copy(sb.text)
+            vscode.env.clipboard.writeText(sb.text)
         }
     });
     context.subscriptions.push(disposable);

--- a/package.json
+++ b/package.json
@@ -56,9 +56,7 @@
     "type": "git",
     "url": "https://github.com/RoscoP/ActiveFileInStatusBar"
   },
-  "dependencies": {
-    "copy-paste": "^1.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "vscode": "0.10.x"
   }


### PR DESCRIPTION
Will fix #25. By using the clipboard API provided by VSCode, copying will work even for remote development.
https://code.visualstudio.com/api/advanced-topics/remote-extensions#using-the-clipboard

I have confirmed that it works with VSCode version 1.62, but I don't know in detail from which version the clipboard API can be used.